### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,3 +1,5 @@
+permissions:
+    contents: read
 name: PR Build Check
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/jheisonnovak/clean-nestjs-cli/security/code-scanning/2](https://github.com/jheisonnovak/clean-nestjs-cli/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` block in the workflow to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since this workflow only checks out code and builds the project, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (after the `name` field and before `on:`), so it applies to all jobs. No changes to steps or other logic are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
