### PR TITLE
fix: derive project name with path.basename for cross-platform support

### DIFF
--- a/src/generators/app.generator.ts
+++ b/src/generators/app.generator.ts
@@ -28,8 +28,7 @@ import { getInstallCommand } from "../utils/get-install-command";
 export class AppGenerator {
 	static async generate(projectNameKebab: string, options: { linters: boolean }): Promise<void> {
 		const projectDir = path.join(process.cwd(), projectNameKebab);
-		const resourceArray = projectDir.split("\\");
-		const projectName = resourceArray[resourceArray.length - 1];
+		const projectName = path.basename(projectDir);
 		const questions = this.getQuestions();
 		console.clear();
 		inquirer


### PR DESCRIPTION
This fixes the package.json name generated by cnest new on macOS/Linux.

The project name was extracted by splitting the project directory on the Windows separator. On macOS/Linux the separator is /, so the split returned the full absolute path and package.json ended up with an absolute path as its name, causing yarn/npm install to fail with the error: Name contains illegal characters. The fix uses path.basename, which is cross-platform.

Testing: build passes; all 45 tests pass via vitest; verified on macOS that the generated package.json now has the correct project name and yarn install succeeds.

Fixes #203.